### PR TITLE
Refactor the way full packets are detected

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -122,12 +122,12 @@ func TestCommands(t *testing.T) {
 
 	t.Run("FlushedIncr", compareOutput(
 		func() {
-			client.Incr("req.count", 30)
+			client.Incr("req.count", 40)
 			client.Incr("req.count", 20)
 			time.Sleep(150 * time.Millisecond)
 			client.Incr("req.count", 10)
 		},
-		[]string{"foo.req.count:30|c\nfoo.req.count:20|c", "foo.req.count:10|c"}))
+		[]string{"foo.req.count:40|c\nfoo.req.count:20|c", "foo.req.count:10|c"}))
 
 	t.Run("SplitIncr", compareOutput(
 		func() {
@@ -136,8 +136,8 @@ func TestCommands(t *testing.T) {
 			}
 		},
 		[]string{
-			"foo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c",
-			"foo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c",
+			"foo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c",
+			"foo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c\nfoo.req.count:30|c",
 		}))
 
 	_ = client.Close()

--- a/loops.go
+++ b/loops.go
@@ -45,7 +45,7 @@ func (c *Client) flushLoop() {
 		case <-c.shutdown:
 			c.bufLock.Lock()
 			if len(c.buf) > 0 {
-				c.flushBuf()
+				c.flushBuf(len(c.buf))
 			}
 			c.bufLock.Unlock()
 
@@ -54,7 +54,7 @@ func (c *Client) flushLoop() {
 		case <-flushC:
 			c.bufLock.Lock()
 			if len(c.buf) > 0 {
-				c.flushBuf()
+				c.flushBuf(len(c.buf))
 			}
 			c.bufLock.Unlock()
 		}


### PR DESCRIPTION
Client was trying to estimate size of the next metric before actually producing
it to guess whether next metric is going to overflow the buffer, which has never
been easy nor precise.

Refactor that code to always append metric first, and check for overflow next.
When overflow happens, slice part before overflow for deliver and save tail to
be initial content of the next buffer.

The price is extra 1K added to the capacity of each buffer to avoid extra allocation
on overflow.