### PR TITLE
Implement support for statsd tags

### DIFF
--- a/options.go
+++ b/options.go
@@ -113,6 +113,17 @@ type ClientOptions struct {
 	// Default value is 1, so packets are sent from single goroutine, this
 	// value might need to be bumped under high load
 	SendLoopCount int
+
+	// TagFormat controls formatting of StatsD tags
+	//
+	// If tags are not used, value of this setting isn't used.
+	//
+	// There are two predefined formats: for InfluxDB and Datadog, default
+	// format is InfluxDB tag format.
+	TagFormat *TagFormat
+
+	// DefaultTags is a list of tags to be applied to every metric
+	DefaultTags []Tag
 }
 
 // Option is type for option implementation
@@ -220,5 +231,22 @@ func SendQueueCapacity(capacity int) Option {
 func SendLoopCount(threads int) Option {
 	return func(c *ClientOptions) {
 		c.SendLoopCount = threads
+	}
+}
+
+// TagStyle controls formatting of StatsD tags
+//
+// There are two predefined formats: for InfluxDB and Datadog, default
+// format is InfluxDB tag format.
+func TagStyle(style *TagFormat) Option {
+	return func(c *ClientOptions) {
+		c.TagFormat = style
+	}
+}
+
+// DefaultTags defines a list of tags to be applied to every metric
+func DefaultTags(tags ...Tag) Option {
+	return func(c *ClientOptions) {
+		c.DefaultTags = tags
 	}
 }

--- a/statsd.go
+++ b/statsd.go
@@ -25,6 +25,41 @@ Ideas were borrowed from the following stastd clients:
  * https://github.com/alexcesaro/statsd/
  * https://github.com/armon/go-metrics
 
+Usage
+
+Initialize client instance with options, one client per application is usually enough:
+
+    client := statsd.NewClient("localhost:8125",
+        statsd.MaxPacketSize(1400),
+        statsd.MetricPrefix("web."))
+
+Send metrics as events happen in the application, metrics will be packed together and
+delivered to statsd server:
+
+    start := time.Now()
+    client.Incr("requests.http", 1)
+    ...
+    client.PrecisionTiming("requests.route.api.latency", time.Since(start))
+
+Shutdown client during application shutdown to flush all the pending metrics:
+
+    client.Close()
+
+Tagging
+
+Metrics could be tagged to support aggregation on TSDB side. go-statsd supports
+tags in InfluxDB and Datadog formats. Format and default tags (applied to every
+metric) are passed as options to the client initialization:
+
+    client := statsd.NewClient("localhost:8125",
+        statsd.TagStyle(TagFormatDatadog),
+        statsd.DefaultTags(statsd.StringTag("app", "billing")))
+
+For every metric sent, tags could be added as the last argument(s) to the function
+call:
+
+    client.Incr("request", 1,
+        statsd.StringTag("procotol", "http"), statsd.IntTag("port", 80))
 */
 package statsd
 

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,130 @@
+package statsd
+
+/*
+
+Copyright (c) 2018 Andrey Smirnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+import "strconv"
+
+// Tag placement constants
+const (
+	TagPlacementName = iota
+	TagPlacementSuffix
+)
+
+// TagFormat controls tag formatting style
+type TagFormat struct {
+	// FirstSeparator is put after metric name and before first tag
+	FirstSeparator string
+	// Placement specifies part of the message to append tags to
+	Placement byte
+	// OtherSeparator separates 2nd and subsequent tags from each other
+	OtherSeparator byte
+	// KeyValueSeparator separates tag name and tag value
+	KeyValueSeparator byte
+}
+
+// Tag types
+const (
+	typeString = iota
+	typeInt64
+)
+
+// Tag is metric-specific tag
+type Tag struct {
+	name     string
+	strvalue string
+	intvalue int64
+	typ      byte
+}
+
+// Append formats tag and appends it to the buffer
+func (tag Tag) Append(buf []byte, style *TagFormat) []byte {
+	buf = append(buf, []byte(tag.name)...)
+	buf = append(buf, style.KeyValueSeparator)
+	if tag.typ == typeString {
+		return append(buf, []byte(tag.strvalue)...)
+	}
+	return strconv.AppendInt(buf, tag.intvalue, 10)
+}
+
+// StringTag creates Tag with string value
+func StringTag(name, value string) Tag {
+	return Tag{name: name, strvalue: value, typ: typeString}
+}
+
+// IntTag creates Tag with integer value
+func IntTag(name string, value int) Tag {
+	return Tag{name: name, intvalue: int64(value), typ: typeInt64}
+}
+
+// Int64Tag creates Tag with integer value
+func Int64Tag(name string, value int64) Tag {
+	return Tag{name: name, intvalue: value, typ: typeInt64}
+}
+
+func (c *Client) formatTags(buf []byte, tags []Tag) []byte {
+	tagsLen := len(c.options.DefaultTags) + len(tags)
+	if tagsLen == 0 {
+		return buf
+	}
+
+	buf = append(buf, []byte(c.options.TagFormat.FirstSeparator)...)
+	for i := range c.options.DefaultTags {
+		buf = c.options.DefaultTags[i].Append(buf, c.options.TagFormat)
+		if i != tagsLen-1 {
+			buf = append(buf, c.options.TagFormat.OtherSeparator)
+		}
+	}
+
+	for i := range tags {
+		buf = tags[i].Append(buf, c.options.TagFormat)
+		if i+len(c.options.DefaultTags) != tagsLen-1 {
+			buf = append(buf, c.options.TagFormat.OtherSeparator)
+		}
+	}
+
+	return buf
+}
+
+var (
+	// TagFormatInfluxDB is format for InfluxDB StatsD telegraf plugin
+	//
+	// Docs: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd
+	TagFormatInfluxDB = &TagFormat{
+		Placement:         TagPlacementName,
+		FirstSeparator:    ",",
+		OtherSeparator:    ',',
+		KeyValueSeparator: '=',
+	}
+
+	// TagFormatDatadog is format for DogStatsD (Datadog Agent)
+	//
+	// Docs: https://docs.datadoghq.com/developers/dogstatsd/#datagram-format
+	TagFormatDatadog = &TagFormat{
+		Placement:         TagPlacementSuffix,
+		FirstSeparator:    "|#",
+		OtherSeparator:    ',',
+		KeyValueSeparator: ':',
+	}
+)

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,0 +1,70 @@
+package statsd
+
+/*
+
+Copyright (c) 2017 Andrey Smirnov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+import "testing"
+
+func TestTags(t *testing.T) {
+	compare := func(tag Tag, style *TagFormat, expected string) func(*testing.T) {
+		return func(t *testing.T) {
+			buf := tag.Append([]byte{}, style)
+
+			if string(buf) != expected {
+				t.Errorf("unexpected tag format: %#v != %#v", string(buf), expected)
+			}
+		}
+	}
+
+	t.Run("StringDatadog",
+		compare(StringTag("name", "value"), TagFormatDatadog, "name:value"))
+	t.Run("StringInflux",
+		compare(StringTag("name", "value"), TagFormatInfluxDB, "name=value"))
+	t.Run("IntDatadog",
+		compare(IntTag("foo", -33), TagFormatDatadog, "foo:-33"))
+	t.Run("IntInflux",
+		compare(IntTag("foo", -33), TagFormatInfluxDB, "foo=-33"))
+	t.Run("Int64Datadog",
+		compare(Int64Tag("foo", 1024*1024*1024*1024), TagFormatDatadog, "foo:1099511627776"))
+	t.Run("Int64Influx",
+		compare(Int64Tag("foo", 1024*1024*1024*1024), TagFormatInfluxDB, "foo=1099511627776"))
+}
+
+func TestFormatTags(t *testing.T) {
+	compare := func(tags []Tag, style *TagFormat, expected string) func(*testing.T) {
+		return func(t *testing.T) {
+			client := NewClient("127.0.0.1:4444", TagStyle(style), DefaultTags(StringTag("host", "foo")))
+			buf := client.formatTags([]byte{}, tags)
+
+			if string(buf) != expected {
+				t.Errorf("unexpected tag format: %#v != %#v", string(buf), expected)
+			}
+		}
+	}
+
+	t.Run("Datadog",
+		compare([]Tag{StringTag("type", "web"), IntTag("status", 200)}, TagFormatDatadog, "|#host:foo,type:web,status:200"))
+	t.Run("Influx",
+		compare([]Tag{StringTag("type", "web"), IntTag("status", 200)}, TagFormatInfluxDB, ",host=foo,type=web,status=200"))
+}


### PR DESCRIPTION
This implements both InfluxDB and Datadog-style tags. Even
with tags go-statsd still preservers zero-allocation
quality.

Tags could be added to any metric, in either InfluxDB or
Datadog formats.

Fixes #2