### PR TITLE
Allow using any logger

### DIFF
--- a/options.go
+++ b/options.go
@@ -25,7 +25,6 @@ SOFTWARE.
 */
 
 import (
-	"log"
 	"time"
 )
 
@@ -42,6 +41,12 @@ const (
 	DefaultSendQueueCapacity = 10
 	DefaultSendLoopCount     = 1
 )
+
+// SomeLogger defines logging interface that allows using 3rd party loggers
+// (e.g. github.com/sirupsen/logrus) with this Statsd client.
+type SomeLogger interface {
+	Printf(fmt string, args ...interface{})
+}
 
 // ClientOptions are statsd client settings
 type ClientOptions struct {
@@ -90,7 +95,7 @@ type ClientOptions struct {
 	// Logger is used by statsd client to report errors and lost packets
 	//
 	// If not set, default logger to stderr with prefix `[STATSD] ` is being used
-	Logger *log.Logger
+	Logger SomeLogger
 
 	// BufPoolCapacity controls size of pre-allocated buffer cache
 	//
@@ -200,7 +205,7 @@ func ReportInterval(interval time.Duration) Option {
 // Logger is used by statsd client to report errors and lost packets
 //
 // If not set, default logger to stderr with prefix `[STATSD] ` is being used
-func Logger(logger *log.Logger) Option {
+func Logger(logger SomeLogger) Option {
 	return func(c *ClientOptions) {
 		c.Logger = logger
 	}


### PR DESCRIPTION
With this change you can initialize a client logger with any logger implementation that provides `Printf(fmt string, args... interface{})` function and not just the standard one.

I was going to name the logger interface just `Logger`, but unfortunately this name had already been taken by a functional parameter, and it is too late to rename functional parameters to follow `With...` convention.