### PR TITLE
Add clone methods

### DIFF
--- a/options.go
+++ b/options.go
@@ -53,7 +53,7 @@ type ClientOptions struct {
 	// Addr is statsd server address in "host:port" format
 	Addr string
 
-	// MetricPrefix is prefix to prepend to every metric being sent
+	// MetricPrefix is metricPrefix to prepend to every metric being sent
 	//
 	// If not set defaults to empty string
 	MetricPrefix string
@@ -94,7 +94,7 @@ type ClientOptions struct {
 
 	// Logger is used by statsd client to report errors and lost packets
 	//
-	// If not set, default logger to stderr with prefix `[STATSD] ` is being used
+	// If not set, default logger to stderr with metricPrefix `[STATSD] ` is being used
 	Logger SomeLogger
 
 	// BufPoolCapacity controls size of pre-allocated buffer cache
@@ -131,15 +131,15 @@ type ClientOptions struct {
 	DefaultTags []Tag
 }
 
-// Option is type for option implementation
+// Option is type for option transport
 type Option func(c *ClientOptions)
 
-// MetricPrefix is prefix to prepend to every metric being sent
+// MetricPrefix is metricPrefix to prepend to every metric being sent
 //
 // Usually metrics are prefixed with app name, e.g. `app.`.
-// To avoid providing this prefix for every metric being collected,
+// To avoid providing this metricPrefix for every metric being collected,
 // and to enable shared libraries to collect metric under app name,
-// use MetricPrefix to set global prefix for all the app metrics,
+// use MetricPrefix to set global metricPrefix for all the app metrics,
 // e.g. `MetricPrefix("app".)`.
 //
 // If not set defaults to empty string
@@ -204,7 +204,7 @@ func ReportInterval(interval time.Duration) Option {
 
 // Logger is used by statsd client to report errors and lost packets
 //
-// If not set, default logger to stderr with prefix `[STATSD] ` is being used
+// If not set, default logger to stderr with metricPrefix `[STATSD] ` is being used
 func Logger(logger SomeLogger) Option {
 	return func(c *ClientOptions) {
 		c.Logger = logger

--- a/statsdbench_test.go
+++ b/statsdbench_test.go
@@ -15,8 +15,8 @@ import (
 
 const (
 	addr        = ":0"
-	prefix      = "prefix."
-	prefixNoDot = "prefix"
+	prefix      = "metricPrefix."
+	prefixNoDot = "metricPrefix"
 	counterKey  = "foo.bar.counter"
 	gaugeKey    = "foo.bar.gauge"
 	gaugeValue  = 42

--- a/tags.go
+++ b/tags.go
@@ -84,23 +84,23 @@ func Int64Tag(name string, value int64) Tag {
 }
 
 func (c *Client) formatTags(buf []byte, tags []Tag) []byte {
-	tagsLen := len(c.options.DefaultTags) + len(tags)
+	tagsLen := len(c.defaultTags) + len(tags)
 	if tagsLen == 0 {
 		return buf
 	}
 
-	buf = append(buf, []byte(c.options.TagFormat.FirstSeparator)...)
-	for i := range c.options.DefaultTags {
-		buf = c.options.DefaultTags[i].Append(buf, c.options.TagFormat)
+	buf = append(buf, []byte(c.trans.tagFormat.FirstSeparator)...)
+	for i := range c.defaultTags {
+		buf = c.defaultTags[i].Append(buf, c.trans.tagFormat)
 		if i != tagsLen-1 {
-			buf = append(buf, c.options.TagFormat.OtherSeparator)
+			buf = append(buf, c.trans.tagFormat.OtherSeparator)
 		}
 	}
 
 	for i := range tags {
-		buf = tags[i].Append(buf, c.options.TagFormat)
-		if i+len(c.options.DefaultTags) != tagsLen-1 {
-			buf = append(buf, c.options.TagFormat.OtherSeparator)
+		buf = tags[i].Append(buf, c.trans.tagFormat)
+		if i+len(c.defaultTags) != tagsLen-1 {
+			buf = append(buf, c.trans.tagFormat.OtherSeparator)
 		}
 	}
 


### PR DESCRIPTION
Sometimes in one application different subsystems use different metric prefixes. To help with that this PR introduces methods `CloneWithPrefix` and `CloneWithPrefixExtension` that return a new client object that has new prefix or original prefix + new prefix respectively. The new clients reuse the transport infrastructure of the original client. Closing an original client or any of its clones makes all of them stop. It is safe to call Close any number of times on any client by the way.