### PR TITLE
Fix typo in MetricPrefix option

### DIFF
--- a/options.go
+++ b/options.go
@@ -140,7 +140,7 @@ type Option func(c *ClientOptions)
 // To avoid providing this metricPrefix for every metric being collected,
 // and to enable shared libraries to collect metric under app name,
 // use MetricPrefix to set global metricPrefix for all the app metrics,
-// e.g. `MetricPrefix("app".)`.
+// e.g. `MetricPrefix("app.")`.
 //
 // If not set defaults to empty string
 func MetricPrefix(prefix string) Option {


### PR DESCRIPTION
Hello. I am using your library well.

While reading the code, I found and corrected a typo.